### PR TITLE
Fix JupyterLite version to 0.1.0b17.

### DIFF
--- a/.github/workflows/jupyterlite.yml
+++ b/.github/workflows/jupyterlite.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install jupyterlite[all] libarchive-c build pyodide-build
+          python -m pip install jupyterlite[all]==0.1.0b17 libarchive-c build pyodide-build
 
       - name: Build xDSL source distribution
         run: |


### PR DESCRIPTION
This fixes importing from "local" directories in JupyterLite.