### PR TITLE
update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-xdsl -e git+https://github.com/xdslproject/xdsl.git@62cb4d4a0f36db74ce88d2dae5d7eeb76b5d01ed#egg={xdsl}
-riscemu -e git+https://github.com/antonlydike/riscemu.git@b5ebe13528cdfe454438e4da6b3d76a3dda2ed1f#egg={riscemu}
+git+https://github.com/xdslproject/xdsl.git@fb52173d12a7b7f48cb716fdab95ce6cecab0fa4#egg=xdsl
+git+https://github.com/antonlydike/riscemu.git@b5ebe13528cdfe454438e4da6b3d76a3dda2ed1f#egg=riscemu


### PR DESCRIPTION
I'm not sure if I did it correctly, but the old format was just installing xdsl from pypi, not the specified commits. This now works correctly on my machine with `pip install -U -r requirements.txt`.